### PR TITLE
Increase timeouts to account for more CPU-intensive pyxform

### DIFF
--- a/provisioning/roles/xlsform/templates/gunicorn.service.j2
+++ b/provisioning/roles/xlsform/templates/gunicorn.service.j2
@@ -7,7 +7,7 @@ User=ubuntu
 Group=www-data
 WorkingDirectory={{ source_home }}
 EnvironmentFile={{ site_home }}/environment
-ExecStart={{ virtualenv_home }}/bin/gunicorn --access-logfile - --workers 3 --bind unix:{{ source_home }}/{{ project_name }}.sock {{ project_name }}.wsgi:application
+ExecStart={{ virtualenv_home }}/bin/gunicorn --access-logfile - --workers 3 --timeout 600 --bind unix:{{ source_home }}/{{ project_name }}.sock {{ project_name }}.wsgi:application
 
 [Install]
 WantedBy=multi-user.target

--- a/provisioning/roles/xlsform/templates/xlsform.j2
+++ b/provisioning/roles/xlsform/templates/xlsform.j2
@@ -11,5 +11,9 @@ server {
     location / {
         include proxy_params;
         proxy_pass http://unix:{{ source_home }}/{{ project_name }}.sock;
+        proxy_connect_timeout 600;
+        proxy_send_timeout 600;
+        proxy_read_timeout 600;
+        send_timeout 600;
     }
 }


### PR DESCRIPTION
Fix for https://forum.opendatakit.org/t/16866.

There seems to be a performance regression on pyxform. Or rather, it seems to requires a lot of CPU. This is fine on a local machine, but on a cloud machine, we are limited by single-core performance.

I'd like to fix this upstream, but for now 600s timeouts worked for the enormous test form I have access to.