### PR TITLE
Restart workers at random times (jitter) to reduce leaks

### DIFF
--- a/provisioning/roles/xlsform/templates/gunicorn.service.j2
+++ b/provisioning/roles/xlsform/templates/gunicorn.service.j2
@@ -7,7 +7,7 @@ User=ubuntu
 Group=www-data
 WorkingDirectory={{ source_home }}
 EnvironmentFile={{ site_home }}/environment
-ExecStart={{ virtualenv_home }}/bin/gunicorn --access-logfile - --workers 5 --timeout 600 --bind unix:{{ source_home }}/{{ project_name }}.sock {{ project_name }}.wsgi:application
+ExecStart={{ virtualenv_home }}/bin/gunicorn --access-logfile - --workers 5 --max-requests 25 --max-requests-jitter 5 --timeout 600 --bind unix:{{ source_home }}/{{ project_name }}.sock {{ project_name }}.wsgi:application
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
There seems to be a memory leak in xlsform-online. It manifests for users with a `java not found` error message.
![image](https://user-images.githubusercontent.com/32369/91124482-288a1200-e654-11ea-92d6-64b25719e385.png)

This happens every 2-3 weeks and my latest investigation found that we are using a lot of memory over time. My guess is that we eventually hit swap and a very large form conversion eventually blows through swap. That causes Java to crash and the bad things happen.

You can see the memory usage here.
<img width="866" alt="Screen Shot 2020-08-24 at 9 51 57 PM" src="https://user-images.githubusercontent.com/32369/91124424-0c867080-e654-11ea-9fa6-487ffa44804b.png">

`systemctl restart gunicorn` seems to the fix the problem, so @lognaturel suggested we do that occasionally with cron. I poked around and found an article on using max-requests and max-requests-jitter to periodically restart workers.

From the analytics, we get ~500 users a day (so ~20/hour). This PR rounds up and says that each worker gets 25 requests (so about an hour) before it restarts. jitter keeps the number changing so workers don't restart at the same time.

With this PR, memory usage stabilizes at 20%.
<img width="801" alt="Screen Shot 2020-08-25 at 1 30 10 PM" src="https://user-images.githubusercontent.com/32369/91224560-2321db80-e6d7-11ea-919f-4439060a7cc8.png">
